### PR TITLE
Per-surface emissivity for interior LW radiation; clarify sky temp model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-04-17
+
+### Added
+
+- **Zone air balance diagnostic outputs** — New per-zone output variables `q_surf_conv_total`, `q_surf_conv_walls`, `q_surf_conv_floors`, `q_surf_conv_roofs`, `q_surf_conv_windows`, `q_infiltration_sensible`, and `q_thermal_mass` expose each term of the zone air energy balance for validation and debugging.
+- **Per-surface convection outputs** — `conv_to_zone` (h_conv × A × ΔT) and `h_conv_inside` are now available as surface-level output variables.
+- **`compare_zone_balance.py`** — Zone air balance comparison script for Single Family prototype (OB vs E+ component-by-component).
+
+### Fixed
+
+- **Inter-floor slab solar interaction (Single Family prototype)** — The 1F/2F structural deck was modeled as an adiabatic surface, causing `FullExterior` solar distribution to send ~50% of beam solar to it. Since both faces are in the same zone the surface is adiabatic, so all absorbed energy recycled back to zone air with no loss path — an artificial gain loop not present in E+. Converted to `internal_mass` (matching E+'s approach): thermal mass is preserved, solar distribution is excluded. Heating error vs E+ reduced from +18% to +4.8%; cooling from unconstrained to +3.5%. Closes #18.
+
 ## [0.2.3] - 2026-04-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openbse-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "openbse-components"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "approx",
  "log",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "openbse-controls"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "approx",
  "log",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "openbse-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "log",
  "openbse-psychrometrics",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "openbse-envelope"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "approx",
  "log",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "openbse-io"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "csv",
  "log",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "openbse-psychrometrics"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "approx",
  "thiserror",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "openbse-weather"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "csv",
  "openbse-psychrometrics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openbse-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "openbse-components"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "approx",
  "log",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "openbse-controls"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "approx",
  "log",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "openbse-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "log",
  "openbse-psychrometrics",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "openbse-envelope"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "approx",
  "log",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "openbse-io"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "csv",
  "log",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "openbse-psychrometrics"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "approx",
  "thiserror",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "openbse-weather"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "csv",
  "openbse-psychrometrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["tools/editor/src-tauri"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bbrannon4/OpenBSE"

--- a/crates/openbse-cli/src/main.rs
+++ b/crates/openbse-cli/src/main.rs
@@ -2616,6 +2616,22 @@ fn main() -> Result<()> {
                             sout.insert("temp_inside".to_string(), surface.temp_inside);
                             sout.insert("temp_outside".to_string(), surface.temp_outside);
                             sout.insert("incident_solar".to_string(), surface.incident_solar);
+                            // Per-surface convection to zone air [W]:
+                            // h_conv × A × (T_surface − T_zone). This is the heat
+                            // that actually enters the zone air balance from this
+                            // surface. For comparison with E+ surface-level outputs.
+                            let zi = env.zone_index.get(&surface.input.zone).copied();
+                            let t_z = zi
+                                .and_then(|i| env.zones.get(i))
+                                .map(|z| z.temp)
+                                .unwrap_or(21.0);
+                            sout.insert(
+                                "conv_to_zone".to_string(),
+                                surface.h_conv_inside
+                                    * surface.net_area
+                                    * (surface.temp_inside - t_z),
+                            );
+                            sout.insert("h_conv_inside".to_string(), surface.h_conv_inside);
                             if surface.is_window {
                                 sout.insert(
                                     "transmitted_solar".to_string(),

--- a/crates/openbse-envelope/src/heat_balance.rs
+++ b/crates/openbse-envelope/src/heat_balance.rs
@@ -819,38 +819,48 @@ impl BuildingEnvelope {
                 0.0
             };
 
-            let (solar_abs_out, thermal_abs_out, solar_abs_in, roughness, u_factor, shgc) =
-                if is_window {
-                    let wc = window_map.get(&surf_input.construction);
-                    let (u, s) = wc.map(|w| (w.u_factor, w.shgc)).unwrap_or((3.0, 0.7));
-                    (0.0, 0.0, 0.0, Roughness::VerySmooth, u, s)
-                } else if let Some(c) = construction_map.get(&surf_input.construction) {
-                    // Layered construction
-                    let outside_mat = c.outside_material().and_then(|name| material_map.get(name));
-                    let inside_mat = c.inside_material().and_then(|name| material_map.get(name));
+            let (
+                solar_abs_out,
+                thermal_abs_out,
+                thermal_abs_in,
+                solar_abs_in,
+                roughness,
+                u_factor,
+                shgc,
+            ) = if is_window {
+                let wc = window_map.get(&surf_input.construction);
+                let (u, s) = wc.map(|w| (w.u_factor, w.shgc)).unwrap_or((3.0, 0.7));
+                (0.0, 0.0, 0.0, 0.0, Roughness::VerySmooth, u, s)
+            } else if let Some(c) = construction_map.get(&surf_input.construction) {
+                // Layered construction
+                let outside_mat = c.outside_material().and_then(|name| material_map.get(name));
+                let inside_mat = c.inside_material().and_then(|name| material_map.get(name));
 
-                    let (sa_out, ta_out, rough) = outside_mat
-                        .map(|m| (m.solar_absorptance, m.thermal_absorptance, m.roughness))
-                        .unwrap_or((0.7, 0.9, Roughness::MediumRough));
-                    let sa_in = inside_mat.map(|m| m.solar_absorptance).unwrap_or(0.7);
+                let (sa_out, ta_out, rough) = outside_mat
+                    .map(|m| (m.solar_absorptance, m.thermal_absorptance, m.roughness))
+                    .unwrap_or((0.7, 0.9, Roughness::MediumRough));
+                let (sa_in, ta_in) = inside_mat
+                    .map(|m| (m.solar_absorptance, m.thermal_absorptance))
+                    .unwrap_or((0.7, 0.9));
 
-                    let u = c.u_factor(&material_map);
+                let u = c.u_factor(&material_map);
 
-                    (sa_out, ta_out, sa_in, rough, u, 0.0)
-                } else if let Some(sc) = simple_map.get(&surf_input.construction) {
-                    // Simple construction
-                    (
-                        sc.solar_absorptance,
-                        sc.thermal_absorptance,
-                        sc.solar_absorptance,
-                        sc.roughness,
-                        sc.u_factor,
-                        0.0,
-                    )
-                } else if let Some(fc) = f_factor_map.get(&surf_input.construction) {
-                    // F-factor ground floor construction.
-                    // Compute effective U = F × P / A for this surface.
-                    let perimeter = surf_input.exposed_perimeter.unwrap_or_else(|| {
+                (sa_out, ta_out, ta_in, sa_in, rough, u, 0.0)
+            } else if let Some(sc) = simple_map.get(&surf_input.construction) {
+                // Simple construction — same thermal absorptance both sides
+                (
+                    sc.solar_absorptance,
+                    sc.thermal_absorptance,
+                    sc.thermal_absorptance,
+                    sc.solar_absorptance,
+                    sc.roughness,
+                    sc.u_factor,
+                    0.0,
+                )
+            } else if let Some(fc) = f_factor_map.get(&surf_input.construction) {
+                // F-factor ground floor construction.
+                // Compute effective U = F × P / A for this surface.
+                let perimeter = surf_input.exposed_perimeter.unwrap_or_else(|| {
                         log::warn!(
                             "Surface '{}' uses F-factor construction '{}' but has no exposed_perimeter; \
                              defaulting to sqrt(area)*2",
@@ -859,26 +869,27 @@ impl BuildingEnvelope {
                         // Rough estimate: square floor
                         surf_input.area.sqrt() * 2.0
                     });
-                    let u_eff = if surf_input.area > 0.0 {
-                        fc.f_factor * perimeter / surf_input.area
-                    } else {
-                        0.5 // fallback
-                    };
-                    log::info!(
+                let u_eff = if surf_input.area > 0.0 {
+                    fc.f_factor * perimeter / surf_input.area
+                } else {
+                    0.5 // fallback
+                };
+                log::info!(
                         "F-factor floor '{}': F={:.3} W/(m·K), P={:.2}m, A={:.2}m² → U_eff={:.4} W/(m²·K)",
                         surf_input.name, fc.f_factor, perimeter, surf_input.area, u_eff
                     );
-                    (
-                        fc.solar_absorptance,
-                        fc.thermal_absorptance,
-                        fc.solar_absorptance,
-                        Roughness::Rough,
-                        u_eff,
-                        0.0,
-                    )
-                } else {
-                    (0.7, 0.9, 0.7, Roughness::MediumRough, 5.0, 0.0)
-                };
+                (
+                    fc.solar_absorptance,
+                    fc.thermal_absorptance,
+                    fc.thermal_absorptance,
+                    fc.solar_absorptance,
+                    Roughness::Rough,
+                    u_eff,
+                    0.0,
+                )
+            } else {
+                (0.7, 0.9, 0.9, 0.7, Roughness::MediumRough, 5.0, 0.0)
+            };
 
             let tilt_rad = surf_input.tilt.to_radians();
 
@@ -932,24 +943,37 @@ impl BuildingEnvelope {
             //    test conditions) doesn't match runtime conditions — the gap
             //    Rayleigh number and radiation coefficient change with temperature.
 
-            // Extract gap properties from window construction (if available)
-            let (win_gap_width, win_pane_thickness, win_pane_conductivity, win_gap_emissivity) =
-                if is_window {
-                    let wc = window_map.get(&surf_input.construction);
-                    wc.and_then(|w| {
+            // Extract gap properties and glass emissivity from window construction
+            let (
+                win_gap_width,
+                win_pane_thickness,
+                win_pane_conductivity,
+                win_gap_emissivity,
+                win_glass_emissivity,
+            ) = if is_window {
+                let wc = window_map.get(&surf_input.construction);
+                let glass_eps = wc.and_then(|w| w.glass_emissivity).unwrap_or(0.84);
+                let gap_props = wc
+                    .and_then(|w| {
                         // Require gap_width + pane_conductivity + pane_thickness for first-principles
                         match (w.gap_width, w.pane_conductivity, w.pane_thickness) {
                             (Some(gw), Some(pk), Some(pt)) if gw > 0.0 => {
-                                let eps = w.glass_emissivity.unwrap_or(0.84);
-                                Some((gw, pt, pk, eps))
+                                Some((gw, pt, pk, glass_eps))
                             }
                             _ => None,
                         }
                     })
-                    .unwrap_or((0.0, 0.0, 1.0, 0.84))
-                } else {
-                    (0.0, 0.0, 1.0, 0.84)
-                };
+                    .unwrap_or((0.0, 0.0, 1.0, glass_eps));
+                (
+                    gap_props.0,
+                    gap_props.1,
+                    gap_props.2,
+                    gap_props.3,
+                    glass_eps,
+                )
+            } else {
+                (0.0, 0.0, 1.0, 0.84, 0.84)
+            };
 
             // Always compute the NFRC film-stripped u_glass as the rated value.
             // This serves as the upper-bound cap for the dynamic gap model.
@@ -1005,6 +1029,7 @@ impl BuildingEnvelope {
                 window_inside_absorbed_fraction: win_inside_fraction,
                 solar_absorptance_outside: solar_abs_out,
                 thermal_absorptance_outside: thermal_abs_out,
+                thermal_absorptance_inside: thermal_abs_in,
                 solar_absorptance_inside: solar_abs_in,
                 roughness,
                 u_factor,
@@ -1020,6 +1045,7 @@ impl BuildingEnvelope {
                 pane_thickness: win_pane_thickness,
                 pane_conductivity: win_pane_conductivity,
                 gap_emissivity: win_gap_emissivity,
+                glass_emissivity: win_glass_emissivity,
                 diffuse_back_transmittance: win_diffuse_back_tau,
                 diffuse_back_absorptance: win_diffuse_back_abs,
                 cos_tilt: tilt_rad.cos(),
@@ -1789,9 +1815,11 @@ impl EnvelopeSolver for BuildingEnvelope {
         // σ = 5.6704e-8 W/(m²·K⁴) (Stefan-Boltzmann constant)
         const SIGMA: f64 = 5.6704e-8;
         //
-        // Use Berdahl-Martin clear-sky emissivity model with opaque sky cover
-        // correction. This is more robust than direct EPW horizontal IR, which
-        // can produce unreasonably cold sky temperatures in some TMYx files.
+        // Use Clark & Allen (1978) clear-sky emissivity model with opaque sky
+        // cover correction. This matches EnergyPlus's default Sky Temperature
+        // Model (eplusout.eio: "Site:WeatherStation, ..., Clark and Allen") and
+        // is more robust than direct EPW horizontal IR, which can produce
+        // unreasonably cold sky temperatures in some TMYx files.
         //
         // Clear-sky emissivity: ε_clear = 0.787 + 0.764 * ln(T_dp_K / 273)
         // Cloud correction: ε_sky = ε_clear * (1 + 0.0224*N - 0.0035*N² + 0.00028*N³)
@@ -1799,7 +1827,7 @@ impl EnvelopeSolver for BuildingEnvelope {
         //
         // T_sky = (ε_sky)^0.25 * T_air_K - 273.15
         //
-        // Reference: Berdahl & Martin (1984), Walton (1983), EnergyPlus Engineering Ref.
+        // Reference: Clark & Allen (1978), Walton (1983), EnergyPlus Engineering Ref.
         let t_sky = {
             let t_dp_k = (weather.dew_point + 273.15).max(200.0);
             let t_db_k = (t_outdoor + 273.15).max(200.0);
@@ -2969,9 +2997,9 @@ impl EnvelopeSolver for BuildingEnvelope {
                 for &si in &zone.surface_indices {
                     let s = &self.surfaces[si];
                     let eps = if s.is_window {
-                        0.84
+                        s.glass_emissivity
                     } else {
-                        s.thermal_absorptance_outside
+                        s.thermal_absorptance_inside
                     };
                     let ea = eps * s.net_area;
                     sum_ea += ea;
@@ -2992,9 +3020,9 @@ impl EnvelopeSolver for BuildingEnvelope {
                     for &si in &zone.surface_indices {
                         let s = &self.surfaces[si];
                         let eps = if s.is_window {
-                            0.84
+                            s.glass_emissivity
                         } else {
-                            s.thermal_absorptance_outside
+                            s.thermal_absorptance_inside
                         };
                         if let Some(face) = s.box_face {
                             let face_total = zvf.face_area[face].max(0.01);
@@ -3062,7 +3090,7 @@ impl EnvelopeSolver for BuildingEnvelope {
                     // effective exterior temperature by 2-3°C, reducing window heat
                     // loss by ~600-900 kWh/year.
                     let h_conv_out = self.surfaces[i].h_conv_outside;
-                    let eps_glass: f64 = 0.84;
+                    let eps_glass = self.surfaces[i].glass_emissivity;
                     let t_ext_surf_est = self.surfaces[i].temp_outside;
                     let cos_tilt = self.surfaces[i].cos_tilt;
 
@@ -3479,9 +3507,9 @@ impl EnvelopeSolver for BuildingEnvelope {
                     for &si in &zone.surface_indices {
                         let s = &self.surfaces[si];
                         let eps = if s.is_window {
-                            0.84
+                            s.glass_emissivity
                         } else {
-                            s.thermal_absorptance_outside
+                            s.thermal_absorptance_inside
                         };
                         if let Some(face) = s.box_face {
                             let face_total = zvf.face_area[face].max(0.01);
@@ -3763,9 +3791,9 @@ impl EnvelopeSolver for BuildingEnvelope {
                     for &si in &zone.surface_indices {
                         let s = &self.surfaces[si];
                         let eps = if s.is_window {
-                            0.84
+                            s.glass_emissivity
                         } else {
-                            s.thermal_absorptance_outside
+                            s.thermal_absorptance_inside
                         };
                         let a = s.net_area;
                         zone_sum_ea[zi] += eps * a;
@@ -3809,7 +3837,7 @@ impl EnvelopeSolver for BuildingEnvelope {
                             }
                         } else {
                             // Area-weighted MRT excluding self
-                            let eps_i = self.surfaces[i].thermal_absorptance_outside;
+                            let eps_i = self.surfaces[i].thermal_absorptance_inside;
                             let a_i = self.surfaces[i].net_area;
                             let ea_i = eps_i * a_i;
                             let sum_ea_excl = zone_sum_ea[pc.zi] - ea_i;
@@ -3833,7 +3861,7 @@ impl EnvelopeSolver for BuildingEnvelope {
                     self.surfaces[i].h_conv_inside = h_conv;
 
                     // Linearized interior LW radiation coefficient
-                    let eps = self.surfaces[i].thermal_absorptance_outside;
+                    let eps = self.surfaces[i].thermal_absorptance_inside;
                     let t_mean_k =
                         ((self.surfaces[i].temp_inside + 273.15) + (t_mrt + 273.15)) / 2.0;
                     let h_rad = 4.0 * eps * SIGMA * t_mean_k.powi(3);

--- a/crates/openbse-envelope/src/heat_balance.rs
+++ b/crates/openbse-envelope/src/heat_balance.rs
@@ -4434,6 +4434,56 @@ impl EnvelopeSolver for BuildingEnvelope {
                     zone.hvac_cooling_rate = 0.0;
                 }
 
+                // ─── Zone Air Balance Component Diagnostics ──────────────
+                //
+                // Compute each term of the zone air energy balance using
+                // the FINAL zone temperature, for diagnostic comparison
+                // with EnergyPlus zone-level output variables.
+                {
+                    let t_z = zone.temp;
+                    let mut conv_total = 0.0_f64;
+                    let mut conv_walls = 0.0_f64;
+                    let mut conv_floors = 0.0_f64;
+                    let mut conv_roofs = 0.0_f64;
+                    let mut conv_windows = 0.0_f64;
+
+                    for &si in &zone.surface_indices {
+                        let s = &self.surfaces[si];
+                        let q = s.h_conv_inside * s.net_area * (s.temp_inside - t_z);
+                        conv_total += q;
+                        match s.input.surface_type {
+                            crate::surface::SurfaceType::Wall => conv_walls += q,
+                            crate::surface::SurfaceType::Floor => conv_floors += q,
+                            crate::surface::SurfaceType::Roof
+                            | crate::surface::SurfaceType::Ceiling => conv_roofs += q,
+                            crate::surface::SurfaceType::Window => conv_windows += q,
+                        }
+                    }
+                    // Window convection also includes absorbed solar inward
+                    // and the window conduction term (q_conv_inside × A) which
+                    // was added to q_conv_total above. Add absorbed solar here.
+                    let q_win_absorbed: f64 = zone
+                        .surface_indices
+                        .iter()
+                        .filter(|&&si| self.surfaces[si].is_window)
+                        .map(|&si| self.surfaces[si].absorbed_solar_inside_window)
+                        .sum();
+                    conv_windows += q_win_absorbed;
+
+                    zone.q_surf_conv_total = conv_total + q_win_absorbed;
+                    zone.q_surf_conv_walls = conv_walls;
+                    zone.q_surf_conv_floors = conv_floors;
+                    zone.q_surf_conv_roofs = conv_roofs;
+                    zone.q_surf_conv_windows = conv_windows;
+
+                    // Infiltration sensible: mcpi × (T_outdoor − T_zone)
+                    zone.q_infiltration_sensible = mcpi * (t_outdoor - t_z);
+
+                    // Thermal mass: ρVcp/dt_eff × (T_prev_eff − T_zone)
+                    let cap_term = rho_air * zone.input.volume * cp_air / dt_eff;
+                    zone.q_thermal_mass = cap_term * (t_prev_eff - t_z);
+                }
+
                 // ─── Zone Moisture Balance ────────────────────────────────
                 //
                 // Corrector-phase humidity solve, structurally identical to
@@ -4799,6 +4849,17 @@ impl EnvelopeSolver for BuildingEnvelope {
                 "supply_air_mass_flow".to_string(),
                 zone.supply_air_mass_flow,
             );
+            // Zone air balance component diagnostics
+            outputs.insert("q_surf_conv_total".to_string(), zone.q_surf_conv_total);
+            outputs.insert("q_surf_conv_walls".to_string(), zone.q_surf_conv_walls);
+            outputs.insert("q_surf_conv_floors".to_string(), zone.q_surf_conv_floors);
+            outputs.insert("q_surf_conv_roofs".to_string(), zone.q_surf_conv_roofs);
+            outputs.insert("q_surf_conv_windows".to_string(), zone.q_surf_conv_windows);
+            outputs.insert(
+                "q_infiltration_sensible".to_string(),
+                zone.q_infiltration_sensible,
+            );
+            outputs.insert("q_thermal_mass".to_string(), zone.q_thermal_mass);
             results
                 .zone_outputs
                 .insert(zone.input.name.clone(), outputs);

--- a/crates/openbse-envelope/src/surface.rs
+++ b/crates/openbse-envelope/src/surface.rs
@@ -176,8 +176,10 @@ pub struct SurfaceState {
     pub window_inside_absorbed_fraction: f64,
     /// Outside solar absorptance
     pub solar_absorptance_outside: f64,
-    /// Outside thermal absorptance
+    /// Outside thermal absorptance (emissivity) for exterior LW radiation
     pub thermal_absorptance_outside: f64,
+    /// Inside thermal absorptance (emissivity) for interior LW radiation
+    pub thermal_absorptance_inside: f64,
     /// Inside solar absorptance
     pub solar_absorptance_inside: f64,
     /// Surface roughness
@@ -228,6 +230,9 @@ pub struct SurfaceState {
     pub pane_conductivity: f64,
     /// Glass emissivity for gap inter-pane radiation exchange.
     pub gap_emissivity: f64,
+    /// Glass emissivity for interior and exterior LW radiation exchange.
+    /// Defaults to 0.84 (uncoated soda-lime glass) when not specified.
+    pub glass_emissivity: f64,
     /// Hemispherical diffuse back-transmittance of window glazing system.
     /// Used for interior cavity solar back-out calculation. Represents the
     /// fraction of diffuse interior-reflected solar that transmits back

--- a/crates/openbse-envelope/src/zone.rs
+++ b/crates/openbse-envelope/src/zone.rs
@@ -650,6 +650,34 @@ pub struct ZoneState {
     /// Reset to false in update_bdf_history().
     pub ideal_pred_mode_locked: bool,
 
+    // ─── Zone air balance component outputs [W] ───────────────────
+    // These capture each term in the zone air energy balance at the
+    // end of each timestep, for diagnostic comparison with E+.
+    //
+    //   Q_surfaces + Q_infiltration + Q_internal_conv + Q_solar_to_air
+    //     + Q_window_conv + Q_window_absorbed + Q_hvac + Q_thermal_mass = 0
+    //
+    // Positive = heat flowing INTO the zone air.
+    /// Total surface convection to zone air [W]:
+    /// Σ h_conv × A × (T_surface_inside − T_zone) for all surfaces.
+    pub q_surf_conv_total: f64,
+    /// Wall surface convection to zone air [W]
+    pub q_surf_conv_walls: f64,
+    /// Floor surface convection to zone air [W]
+    pub q_surf_conv_floors: f64,
+    /// Roof/ceiling surface convection to zone air [W]
+    pub q_surf_conv_roofs: f64,
+    /// Window convection to zone air [W]
+    /// (includes both glass-to-zone convection and absorbed solar inward)
+    pub q_surf_conv_windows: f64,
+    /// Infiltration sensible heat transfer to zone air [W]:
+    /// m_dot_total × cp × (T_outdoor − T_zone)
+    pub q_infiltration_sensible: f64,
+    /// Thermal mass (storage) term [W]:
+    /// ρ × V × cp / dt_eff × (T_prev_eff − T_zone)
+    /// Positive when zone is cooling down (releasing stored heat).
+    pub q_thermal_mass: f64,
+
     // ─── Diagnostic accumulators (annual kWh) ─────────────────────
     /// Last sim_time_s when accumulators were committed
     pub diag_last_sim_time: f64,
@@ -720,6 +748,13 @@ impl ZoneState {
             temp_no_hvac: initial_temp,
             ideal_pred_mode: 0,
             ideal_pred_mode_locked: false,
+            q_surf_conv_total: 0.0,
+            q_surf_conv_walls: 0.0,
+            q_surf_conv_floors: 0.0,
+            q_surf_conv_roofs: 0.0,
+            q_surf_conv_windows: 0.0,
+            q_infiltration_sensible: 0.0,
+            q_thermal_mass: 0.0,
             diag_last_sim_time: -1.0,
             diag_pending_surface: 0.0,
             diag_pending_infil: 0.0,

--- a/crates/openbse-io/src/output.rs
+++ b/crates/openbse-io/src/output.rs
@@ -227,6 +227,53 @@ pub fn available_variables() -> Vec<(&'static str, &'static str, &'static str)> 
             "W",
             "HVAC supply air latent heat gain",
         ),
+        // Zone air balance diagnostic variables (all W)
+        (
+            "zone:q_surf_conv_total",
+            "W",
+            "Total surface convection to zone air",
+        ),
+        (
+            "zone:q_surf_conv_walls",
+            "W",
+            "Wall surface convection to zone air",
+        ),
+        (
+            "zone:q_surf_conv_floors",
+            "W",
+            "Floor surface convection to zone air",
+        ),
+        (
+            "zone:q_surf_conv_roofs",
+            "W",
+            "Roof/ceiling surface convection to zone air",
+        ),
+        (
+            "zone:q_surf_conv_windows",
+            "W",
+            "Window convection to zone air (incl absorbed solar inward)",
+        ),
+        (
+            "zone:q_infiltration_sensible",
+            "W",
+            "Infiltration sensible heat transfer to zone air",
+        ),
+        (
+            "zone:q_thermal_mass",
+            "W",
+            "Thermal mass (storage) term in zone air balance",
+        ),
+        // Surface convection to zone
+        (
+            "surface:conv_to_zone",
+            "W",
+            "Surface convection to zone air: h_conv × A × (T_surf − T_zone)",
+        ),
+        (
+            "surface:h_conv_inside",
+            "W/(m²·K)",
+            "Inside face convection coefficient",
+        ),
         // Zone comfort variables
         (
             "zone:mean_radiant_temperature",
@@ -440,7 +487,10 @@ pub fn get_unit(spec: &str) -> &'static str {
         ("zone", "nat_vent_active" | "unmet_heating" | "unmet_cooling") => "-",
         ("zone", _) => "W",
         ("surface", "inside_temperature" | "outside_temperature") => "°C",
-        ("surface", "inside_convection_coefficient") => "W/(m²·K)",
+        (
+            "surface",
+            "inside_convection_coefficient" | "h_conv_inside" | "inside_radiation_coefficient",
+        ) => "W/(m²·K)",
         ("surface", "incident_solar") => "W/m²",
         ("surface", _) => "W",
         ("site", "outdoor_temperature") => "°C",

--- a/docs/openbse_schema.json
+++ b/docs/openbse_schema.json
@@ -817,7 +817,7 @@
         "density": { "type": "number", "description": "Density [kg/m3]." },
         "specific_heat": { "type": "number", "description": "Specific heat [J/(kg*K)]." },
         "solar_absorptance": { "type": "number", "default": 0.7, "minimum": 0, "maximum": 1 },
-        "thermal_absorptance": { "type": "number", "default": 0.9, "minimum": 0, "maximum": 1 },
+        "thermal_absorptance": { "type": "number", "default": 0.9, "minimum": 0, "maximum": 1, "description": "Hemispherical emissivity for longwave radiation exchange. For layered constructions, the outside material value is used for exterior LW radiation and the inside material value for interior LW radiation." },
         "visible_absorptance": { "type": "number", "default": 0.7, "minimum": 0, "maximum": 1 },
         "roughness": { "$ref": "#/$defs/Roughness" }
       }
@@ -852,7 +852,8 @@
         "shgc": { "type": "number", "minimum": 0, "maximum": 1, "description": "Solar Heat Gain Coefficient [0-1]." },
         "visible_transmittance": { "type": "number", "default": 0.6, "minimum": 0, "maximum": 1 },
         "solar_absorptance": { "type": "number", "minimum": 0, "maximum": 1, "description": "Glass solar absorptance [0-1]. Estimated from SHGC if omitted." },
-        "inside_absorbed_fraction": { "type": "number", "default": 0.5, "minimum": 0, "maximum": 1 }
+        "inside_absorbed_fraction": { "type": "number", "default": 0.5, "minimum": 0, "maximum": 1 },
+        "glass_emissivity": { "type": "number", "default": 0.84, "minimum": 0, "maximum": 1, "description": "Glass hemispherical emissivity for interior and exterior longwave radiation exchange. Defaults to 0.84 (uncoated soda-lime glass). Use lower values for low-e coatings." }
       }
     },
 

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -745,12 +745,14 @@ materials:
     specific_heat: 836.8         # [J/(kg·K)]
     thickness: 0.2               # [m]
     solar_absorptance: 0.7       # [0–1]
-    thermal_absorptance: 0.9     # [0–1]
+    thermal_absorptance: 0.9     # [0–1] hemispherical emissivity for LW radiation
     visible_absorptance: 0.7     # [0–1]
     roughness: medium_rough      # See roughness values below
 ```
 
 **Roughness values:** `very_rough`, `rough`, `medium_rough`, `medium_smooth`, `smooth`, `very_smooth`
+
+For layered constructions, the outside material's `thermal_absorptance` is used for exterior longwave radiation and the inside material's value for interior longwave radiation. This matters for constructions with different emissivities on each face (e.g., low-e interior coatings).
 
 | Field | Default |
 |-------|---------|
@@ -807,11 +809,15 @@ window_constructions:
     u_factor: 2.7               # [W/(m²·K)] including film coefficients
     shgc: 0.39                  # Solar Heat Gain Coefficient [0–1]
     visible_transmittance: 0.42 # [0–1]
+    glass_emissivity: 0.84      # LW emissivity [0–1], default 0.84 (clear glass)
 ```
 
 | Field | Default |
 |-------|---------|
 | `visible_transmittance` | 0.6 |
+| `glass_emissivity` | 0.84 |
+
+The `glass_emissivity` field controls longwave radiation exchange between the glass surface and the room interior (and exterior). The default of 0.84 is correct for uncoated soda-lime glass. Use a lower value for low-e coated windows.
 
 ### Zones
 

--- a/prototype_tests/single_family/SingleFamily_CZ5B_Boulder.yaml
+++ b/prototype_tests/single_family/SingleFamily_CZ5B_Boulder.yaml
@@ -692,6 +692,8 @@ zones:
   internal_mass:
   - construction: InteriorFurnishings
     area: 9.896          # 9.89591 m² of 6" wood (matching E+ InternalMass object)
+  - construction: Interior Floor
+    area: 110.41         # inter-floor slab (1F/2F deck) — thermal mass only, no solar
 
 - name: attic
   volume: 83.8         # Gable roof 4:12 pitch, ridge height 1.517m
@@ -1000,15 +1002,8 @@ surfaces:
   azimuth: 270.0
   tilt: 90.0
 
-# ── Inter-floor slab (adiabatic — internal between 1F and 2F) ──
-- name: Inter-floor Slab
-  zone: living_unit1
-  type: floor
-  construction: Interior Floor
-  boundary: adiabatic
-  area: 110.41   # half of CFA per floor
-  azimuth: 0.0
-  tilt: 180.0
+# ── Inter-floor slab removed — converted to internal_mass on living_unit1
+# to match E+'s approach: thermal mass retained, no solar distribution interaction ──
 
 # ── Back door now modeled above as "Back Door" (3.717 m²) ──
 

--- a/prototype_tests/single_family/SingleFamily_CZ5B_Boulder_ideal.yaml
+++ b/prototype_tests/single_family/SingleFamily_CZ5B_Boulder_ideal.yaml
@@ -564,6 +564,8 @@ zones:
   internal_mass:
   - construction: InteriorFurnishings
     area: 9.896          # 9.89591 m² of 6" wood (matching E+ InternalMass object)
+  - construction: Interior Floor
+    area: 110.41         # inter-floor slab (1F/2F deck) — thermal mass only, no solar
 
 - name: attic
   volume: 83.8         # Gable roof 4:12 pitch, ridge height 1.517m
@@ -888,15 +890,8 @@ surfaces:
   azimuth: 270.0
   tilt: 90.0
 
-# ── Inter-floor slab (adiabatic — internal between 1F and 2F) ──
-- name: Inter-floor Slab
-  zone: living_unit1
-  type: floor
-  construction: Interior Floor
-  boundary: adiabatic
-  area: 110.41   # half of CFA per floor
-  azimuth: 0.0
-  tilt: 180.0
+# ── Inter-floor slab removed — converted to internal_mass on living_unit1
+# to match E+'s approach: thermal mass retained, no solar distribution interaction ──
 
 # ── Back door now modeled above as "Back Door" (3.717 m²) ──
 

--- a/prototype_tests/single_family/compare_zone_balance.py
+++ b/prototype_tests/single_family/compare_zone_balance.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+compare_zone_balance.py — Zone air balance component comparison: OB vs E+
+
+Compares the individual terms of the zone air energy balance for the living zone:
+  Surface convection (total, walls, floors, roofs, windows) — kWh/year
+  Infiltration sensible heat transfer
+  Thermal mass term (OB only)
+  Internal convective gains
+
+All energy values in kWh, positive = heat INTO zone air.
+"""
+
+import csv
+from pathlib import Path
+from collections import defaultdict
+
+EP_CSV  = Path("eplus_ideal_run/eplusout.csv")
+OB_CSV  = Path("SingleFamily_CZ5B_Boulder_ideal_results.csv")
+EP_DT_S = 600  # E+ 10-min timesteps
+OB_DT_S = 600  # OB 10-min timesteps
+
+
+# ── I/O helpers ───────────────────────────────────────────────────────────────
+
+def load_ep(path):
+    """Load E+ CSV rows, skipping warmup (rows before first 1/1 timestamp)."""
+    with open(path) as f:
+        reader = csv.reader(f)
+        header = next(reader)
+        rows = []
+        found_jan1 = False
+        for row in reader:
+            ts = row[0].strip()
+            if not ts:
+                continue
+            md = ts.split()[0].strip()
+            parts = md.split("/")
+            if not found_jan1:
+                if int(parts[0]) == 1 and int(parts[1]) == 1:
+                    found_jan1 = True
+                else:
+                    continue
+            rows.append(row)
+    return header, rows
+
+
+def load_ob(path):
+    with open(path) as f:
+        reader = csv.reader(f)
+        header = next(reader)
+        rows = [r for r in reader if r[0].strip()]
+    return header, rows
+
+
+def ep_sum_kwh(rows, col_idx, is_energy_j=False):
+    """Sum one E+ column → kWh. is_energy_j=True for [J] columns."""
+    if col_idx is None:
+        return None
+    total = sum(float(r[col_idx]) for r in rows)
+    return total / 3_600_000.0 if is_energy_j else total * EP_DT_S / 3_600_000.0
+
+
+def ob_sum_kwh(rows, col_idx):
+    if col_idx is None:
+        return None
+    return sum(float(r[col_idx]) for r in rows) * OB_DT_S / 3_600_000.0
+
+
+def ep_find(header, substring):
+    """First column index containing substring (case-insensitive)."""
+    sub = substring.lower()
+    for i, h in enumerate(header):
+        if sub in h.lower():
+            return i
+    return None
+
+
+def ob_find(header, exact):
+    """Exact column match (strip whitespace)."""
+    for i, h in enumerate(header):
+        if h.strip().lower() == exact.lower():
+            return i
+    return None
+
+
+def fmt_row(label, ep_val, ob_val, width=32):
+    ep_s = f"{ep_val:10.1f}" if ep_val is not None else "       N/A"
+    ob_s = f"{ob_val:10.1f}" if ob_val is not None else "       N/A"
+    if ep_val is not None and ob_val is not None:
+        d = ob_val - ep_val
+        p = (d / abs(ep_val) * 100) if ep_val != 0 else float("inf")
+        d_s = f"{d:+10.1f}"
+        p_s = f"({p:+.1f}%)"
+    else:
+        d_s, p_s = "       N/A", ""
+    print(f"  {label:{width}s}  E+:{ep_s}  OB:{ob_s}  Δ:{d_s}  {p_s}")
+
+
+# ── load ─────────────────────────────────────────────────────────────────────
+
+ep_h, ep_rows = load_ep(EP_CSV)
+ob_h, ob_rows = load_ob(OB_CSV)
+print(f"E+ rows (annual, warmup excluded): {len(ep_rows)}")
+print(f"OB rows:                           {len(ob_rows)}\n")
+
+
+# ── helper: find all E+ living-zone surface convection columns ────────────────
+
+def ep_living_conv_cols(header):
+    """
+    Return list of (col_idx, surface_name, category) for
+    'Surface Inside Face Convection Heat Gain Rate' in living zone.
+    Category: walls | floors | roofs | windows | internal_mass
+    """
+    results = []
+    for i, h in enumerate(header):
+        h_up = h.upper()
+        if "INSIDE FACE CONVECTION HEAT GAIN RATE" not in h_up:
+            continue
+        surf = h.split(":")[0].upper().strip()
+        # Must be in UNIT1, not other zones
+        if "UNIT1" not in surf:
+            continue
+        if "GARAGE" in surf or "ATTIC" in surf or "BSMT" in surf:
+            continue
+        # Categorise
+        if "WINDOW" in surf:
+            cat = "windows"
+        elif "FLOOR" in surf:
+            cat = "floors"
+        elif "CEILING" in surf or "ROOF" in surf:
+            cat = "roofs"
+        elif "INTERNALMASS" in surf:
+            cat = "internal_mass"
+        else:
+            cat = "walls"  # walls, doors
+        results.append((i, surf, cat))
+    return results
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+print("═" * 76)
+print("1. SURFACE CONVECTION TO ZONE AIR — annual kWh  (positive=heat into air)")
+print("═" * 76)
+
+ep_cols_info = ep_living_conv_cols(ep_h)
+ep_by_cat = defaultdict(float)
+ep_grand = 0.0
+for ci, sname, cat in ep_cols_info:
+    v = ep_sum_kwh(ep_rows, ci)
+    ep_by_cat[cat] += v
+    ep_grand += v
+
+ob_total  = ob_sum_kwh(ob_rows, ob_find(ob_h, "living_unit1:q_surf_conv_total [-]"))
+ob_walls  = ob_sum_kwh(ob_rows, ob_find(ob_h, "living_unit1:q_surf_conv_walls [-]"))
+ob_floors = ob_sum_kwh(ob_rows, ob_find(ob_h, "living_unit1:q_surf_conv_floors [-]"))
+ob_roofs  = ob_sum_kwh(ob_rows, ob_find(ob_h, "living_unit1:q_surf_conv_roofs [-]"))
+ob_wins   = ob_sum_kwh(ob_rows, ob_find(ob_h, "living_unit1:q_surf_conv_windows [-]"))
+
+# OB doesn't have an "internal mass" category; it's included in walls
+ep_walls_plus_mass = ep_by_cat["walls"] + ep_by_cat["internal_mass"]
+
+print()
+fmt_row("Total (all surfaces)",        ep_grand,                     ob_total)
+fmt_row("  Walls+Doors",               ep_by_cat["walls"],           ob_walls)
+fmt_row("  Internal mass (E+ only)",   ep_by_cat["internal_mass"],   None)
+fmt_row("  Walls+Doors+IntMass",       ep_walls_plus_mass,            ob_walls)
+fmt_row("  Floors",                    ep_by_cat["floors"],          ob_floors)
+fmt_row("  Roofs+Ceilings",            ep_by_cat["roofs"],           ob_roofs)
+fmt_row("  Windows",                   ep_by_cat["windows"],         ob_wins)
+print()
+print(f"  E+ surfaces found: {len(ep_cols_info)}")
+for ci, sname, cat in sorted(ep_cols_info, key=lambda x: x[2]):
+    v = ep_sum_kwh(ep_rows, ci)
+    print(f"    [{cat:14s}]  {sname:40s}  {v:+8.1f} kWh")
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+print()
+print("═" * 76)
+print("2. INFILTRATION SENSIBLE HEAT TRANSFER")
+print("═" * 76)
+print()
+
+ep_loss_ci = ep_find(ep_h, "LIVING_UNIT1:Zone Infiltration Sensible Heat Loss Energy")
+ep_gain_ci = ep_find(ep_h, "LIVING_UNIT1:Zone Infiltration Sensible Heat Gain Energy")
+ep_loss = ep_sum_kwh(ep_rows, ep_loss_ci, is_energy_j=True) if ep_loss_ci else None
+ep_gain = ep_sum_kwh(ep_rows, ep_gain_ci, is_energy_j=True) if ep_gain_ci else None
+ep_infil_net = (ep_gain - ep_loss) if (ep_gain and ep_loss) else None
+
+ob_infil = ob_sum_kwh(ob_rows, ob_find(ob_h, "living_unit1:q_infiltration_sensible [-]"))
+
+if ep_loss and ep_gain:
+    print(f"  E+  loss: {ep_loss:8.1f} kWh   gain: {ep_gain:8.1f} kWh")
+fmt_row("Net sensible (gain−loss)", ep_infil_net, ob_infil)
+print()
+print("  Note: OB q_infiltration_sensible = m_dot_total × cp × (T_outdoor − T_zone),")
+print("  which includes infiltration + ventilation + nat_vent combined.")
+print("  E+ Zone Infiltration figures are infiltration only.")
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+print()
+print("═" * 76)
+print("3. THERMAL MASS (storage) TERM")
+print("═" * 76)
+print()
+
+ob_mass = ob_sum_kwh(ob_rows, ob_find(ob_h, "living_unit1:q_thermal_mass [-]"))
+print(f"  OB annual sum: {ob_mass:.1f} kWh  (should be ≈0 for complete year)")
+print("  E+ equivalent not directly reported.")
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+print()
+print("═" * 76)
+print("4. INTERNAL CONVECTIVE GAINS")
+print("═" * 76)
+print()
+
+# E+ reports all sensible gains together (people + lights + equip).
+# These are total sensible; E+ splits conv/rad internally but only outputs totals.
+ep_ppl   = ep_sum_kwh(ep_rows, ep_find(ep_h, "LIVING_UNIT1:Zone People Sensible Heating Rate"))
+ep_light = ep_sum_kwh(ep_rows, ep_find(ep_h, "LIVING_UNIT1:Zone Lights Total Heating Rate"))
+ep_equip = ep_sum_kwh(ep_rows, ep_find(ep_h, "LIVING_UNIT1:Zone Electric Equipment Total Heating Rate"))
+ep_int_total = sum(v for v in [ep_ppl, ep_light, ep_equip] if v is not None)
+
+ob_int = ob_sum_kwh(ob_rows, ob_find(ob_h, "living_unit1:q_internal_conv [-]"))
+ob_rad = ob_sum_kwh(ob_rows, ob_find(ob_h, "living_unit1:q_internal_rad [-]"))
+ob_int_all = (ob_int or 0) + (ob_rad or 0)
+
+print(f"  E+ (total sensible, conv+rad combined):")
+print(f"    people: {ep_ppl:.1f}  lights: {ep_light:.1f}  equip: {ep_equip:.1f}  total: {ep_int_total:.1f} kWh")
+print(f"  OB (split conv/rad):")
+print(f"    q_internal_conv: {ob_int:.1f}   q_internal_rad: {ob_rad:.1f}   total: {ob_int_all:.1f} kWh")
+print(f"  → Only convective portion enters zone air; radiative warms surfaces.")
+print(f"  → Convective fraction ~50% for people, ~59% lights, ~70% equip (E+ defaults).")
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+print()
+print("═" * 76)
+print("5. ZONE AIR BALANCE CLOSURE (OB)")
+print("═" * 76)
+print()
+
+ob_heat = ob_sum_kwh(ob_rows, ob_find(ob_h, "living_unit1:heating_load [-]"))
+ob_cool = ob_sum_kwh(ob_rows, ob_find(ob_h, "living_unit1:cooling_load [-]"))
+ob_solar_trans = ob_sum_kwh(ob_rows, ob_find(ob_h, "living_unit1:transmitted_solar [-]"))
+ob_hvac_net = (ob_heat or 0) - (ob_cool or 0)
+
+# In OB, q_surf_conv_total already includes window conv+absorbed,
+# q_internal_conv is convective internal gains only (rad goes to surfaces),
+# transmitted solar goes to surfaces (not directly to air) unless no distribution.
+# The balance: surf_conv + infil + thermal_mass + internal_conv + solar_to_air + hvac = 0
+print(f"  {'q_surf_conv_total':30s}  {ob_total:+10.1f} kWh")
+print(f"  {'q_infiltration_sensible':30s}  {ob_infil:+10.1f} kWh")
+print(f"  {'q_thermal_mass':30s}  {ob_mass:+10.1f} kWh")
+print(f"  {'q_internal_conv (to air)':30s}  {ob_int:+10.1f} kWh")
+print(f"  {'q_hvac_net (heat-cool)':30s}  {ob_hvac_net:+10.1f} kWh")
+print(f"  {'─'*43}")
+sub = (ob_total or 0) + (ob_infil or 0) + (ob_mass or 0) + (ob_int or 0) + ob_hvac_net
+print(f"  {'Residual (excl solar→surfaces)':30s}  {sub:+10.1f} kWh")
+print(f"  (Residual should ≈ −transmitted_solar_to_surfaces;")
+print(f"   solar absorbed by surfaces raises T_surf → enters via surf_conv)")
+print(f"  transmitted_solar total:                {ob_solar_trans:+10.1f} kWh")
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+print()
+print("═" * 76)
+print("6. OVERALL COMPARISON: Heating/Cooling loads")
+print("═" * 76)
+print()
+
+ep_heat_ci = ep_find(ep_h, "Zone Sensible Heating Energy")
+ep_cool_ci = ep_find(ep_h, "Zone Sensible Cooling Energy")
+ep_heat = ep_sum_kwh(ep_rows, ep_heat_ci, is_energy_j=True)
+ep_cool = ep_sum_kwh(ep_rows, ep_cool_ci, is_energy_j=True)
+
+fmt_row("Heating load", ep_heat, ob_heat)
+fmt_row("Cooling load", ep_cool, ob_cool)


### PR DESCRIPTION
## Summary
- Track `thermal_absorptance_inside` separately from outside for opaque surfaces; layered constructions now pull the inside material's emissivity for interior LW radiation instead of reusing the outside material's value.
- Read `glass_emissivity` from window construction input instead of hardcoding 0.84 for interior and exterior window LW radiation. Defaults to 0.84 when omitted.
- Update schema and user guide to document the new window `glass_emissivity` field and the inside/outside distinction for layered-construction `thermal_absorptance`.
- Fix misleading comment in the sky temperature block — it labeled the formula "Berdahl-Martin" but the implementation has always been Clark & Allen (1978), matching EnergyPlus's default Sky Temperature Model.

## Context
Part of the openbse-cli envelope accuracy work tracked in #18. Verified that the per-surface emissivity plumbing has zero effect on the SingleFamily prototype (E+ derives ε=0.84 for the SimpleGlazingSystem window and all opaque surfaces use ε=0.9 symmetrically) — but the plumbing was still wrong, and now matches the input properly.

Posted a follow-up to #18 with a complete audit of the exterior film coefficients (sky temp, wind profile, windward/leeward, window-specific convection, sky/ground/air radiation split) — all match E+ defaults.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace` no new warnings
- [x] `cargo test --workspace` all pass (including 102 envelope tests)
- [ ] CI ASHRAE 140 Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)