### PR TITLE
Fix #75 (PR-A): wire openbse-controls live as the zone setpoint authority

### DIFF
--- a/crates/openbse-cli/src/main.rs
+++ b/crates/openbse-cli/src/main.rs
@@ -479,7 +479,7 @@ fn main() -> Result<()> {
             build_graph_with_base(&model, model_dir).context("Failed to build simulation graph")?;
         info!("Graph built: {} components", graph.component_count());
 
-        let controllers = build_controllers(&model);
+        let mut controllers = build_controllers(&model);
         info!("Controllers built: {} controllers", controllers.len());
 
         let mut envelope = build_envelope(
@@ -988,21 +988,88 @@ fn main() -> Result<()> {
         // Output directory (needed by sizing and output writers)
         let output_dir = output_path.parent().unwrap_or_else(|| Path::new("."));
 
-        // Gather zone setpoints from resolved thermostats
+        // Still needed for the has-external-HVAC check below.
         let resolved_thermostats = resolve_thermostats(&model);
+
+        // Gather zone setpoints from the controls framework.
+        //
+        // The openbse-controls layer is the single source of truth for zone
+        // setpoints: the ZoneThermostat controllers built from the model emit
+        // SetZoneSetpoints actions, which we fold into the per-zone maps consumed
+        // by the HVAC engine (`simulate_all_loops`). This makes the controls
+        // crate live on the simulation path (issue #75) and is behavior-
+        // preserving — the emitted setpoints are exactly the resolved-thermostat
+        // values that previously populated these maps directly.
+        //
+        // The thermostat setpoints are static, so the controllers are evaluated
+        // once here. Per-timestep evaluation at the predictor step (needed for
+        // schedule-varying or sensed-state setpoints) belongs with the dynamic
+        // controls work in the #75 follow-up, where it changes behavior and can
+        // be validated on its own.
         let mut zone_heating_setpoints: HashMap<String, f64> = HashMap::new();
         let mut zone_cooling_setpoints: HashMap<String, f64> = HashMap::new();
         let mut zone_unocc_heating_setpoints: HashMap<String, f64> = HashMap::new();
         let mut zone_unocc_cooling_setpoints: HashMap<String, f64> = HashMap::new();
         let mut zone_design_flows: HashMap<String, f64> = HashMap::new();
-        for tstat in &resolved_thermostats {
-            for zone_name in &tstat.zones {
-                zone_heating_setpoints.insert(zone_name.clone(), tstat.heating_setpoint);
-                zone_cooling_setpoints.insert(zone_name.clone(), tstat.cooling_setpoint);
-                zone_unocc_heating_setpoints
-                    .insert(zone_name.clone(), tstat.unoccupied_heating_setpoint);
-                zone_unocc_cooling_setpoints
-                    .insert(zone_name.clone(), tstat.unoccupied_cooling_setpoint);
+
+        {
+            use openbse_controls::state::{ControlAction, SystemState};
+
+            // SetZoneSetpoints is independent of sensed state, so trivial seeds
+            // are sufficient to extract the setpoints from each controller.
+            let seed_air = openbse_psychrometrics::MoistAirState::from_tdb_rh(20.0, 0.5, 101325.0);
+            let seed_state = SystemState::new(seed_air);
+            let seed_ctx = SimulationContext {
+                timestep: TimeStep {
+                    month: config.start_month,
+                    day: config.start_day,
+                    hour: 1,
+                    sub_hour: 1,
+                    timesteps_per_hour: config.timesteps_per_hour,
+                    sim_time_s: 0.0,
+                    dt,
+                },
+                outdoor_air: seed_air,
+                day_type: DayType::WeatherDay,
+                is_sizing: false,
+                sizing_internal_gains: SizingInternalGains::Full,
+            };
+
+            let mut unapplied_controls = 0usize;
+            for controller in controllers.iter_mut() {
+                controller.update(&seed_state, &seed_ctx);
+                for action in controller.actions() {
+                    match action {
+                        ControlAction::SetZoneSetpoints {
+                            zone,
+                            heating_setpoint,
+                            cooling_setpoint,
+                            unoccupied_heating_setpoint,
+                            unoccupied_cooling_setpoint,
+                        } => {
+                            zone_heating_setpoints.insert(zone.clone(), *heating_setpoint);
+                            zone_cooling_setpoints.insert(zone.clone(), *cooling_setpoint);
+                            zone_unocc_heating_setpoints
+                                .insert(zone.clone(), *unoccupied_heating_setpoint);
+                            zone_unocc_cooling_setpoints
+                                .insert(zone.clone(), *unoccupied_cooling_setpoint);
+                        }
+                        // SetpointController / PlantLoopSetpoint actions from the
+                        // `controls:` block. Honored in HVAC-only mode (see the
+                        // ControlSignals built later) but inert on the coupled
+                        // envelope+HVAC path pending the #75 follow-up.
+                        _ => unapplied_controls += 1,
+                    }
+                }
+            }
+
+            if unapplied_controls > 0 && envelope.is_some() {
+                warn!(
+                    "{} explicit `controls:` action(s) parsed but not applied on the coupled \
+                     envelope+HVAC path (setpoint managers / plant-loop setpoints); they take \
+                     effect only in HVAC-only mode. See issue #75.",
+                    unapplied_controls
+                );
             }
         }
 

--- a/crates/openbse-controls/src/state.rs
+++ b/crates/openbse-controls/src/state.rs
@@ -103,6 +103,22 @@ pub enum ControlAction {
 
     /// Set a zone's target supply air temperature [°C]
     SetZoneSupplyTemp { zone: String, supply_temp: f64 },
+
+    /// Set a zone's heating/cooling setpoints (occupied + unoccupied) [°C].
+    ///
+    /// The controller owns the full deadband: it emits both the heating and
+    /// cooling setpoints (plus their unoccupied setback/setup values) rather
+    /// than a single target. The HVAC engine (`simulate_all_loops`) then
+    /// computes the supply response that meets those setpoints — control
+    /// authority (what temperature the zone wants) and capacity response (how
+    /// the system delivers it) stay cleanly separated.
+    SetZoneSetpoints {
+        zone: String,
+        heating_setpoint: f64,
+        cooling_setpoint: f64,
+        unoccupied_heating_setpoint: f64,
+        unoccupied_cooling_setpoint: f64,
+    },
 }
 
 impl ControlAction {
@@ -115,6 +131,7 @@ impl ControlAction {
             ControlAction::SetPlantLoad { component, .. } => component,
             ControlAction::SetZoneAirFlow { zone, .. } => zone,
             ControlAction::SetZoneSupplyTemp { zone, .. } => zone,
+            ControlAction::SetZoneSetpoints { zone, .. } => zone,
         }
     }
 }

--- a/crates/openbse-controls/src/thermostat.rs
+++ b/crates/openbse-controls/src/thermostat.rs
@@ -39,6 +39,14 @@ pub struct ZoneGroup {
     pub heating_setpoint: f64,
     /// Cooling setpoint [°C]
     pub cooling_setpoint: f64,
+    /// Unoccupied (setback) heating setpoint [°C].
+    /// Falls back to `heating_setpoint` (no setback) when unspecified.
+    #[serde(default)]
+    pub unoccupied_heating_setpoint: Option<f64>,
+    /// Unoccupied (setup) cooling setpoint [°C].
+    /// Falls back to `cooling_setpoint` (no setup) when unspecified.
+    #[serde(default)]
+    pub unoccupied_cooling_setpoint: Option<f64>,
     /// Deadband between heating and cooling setpoints [°C]
     /// If not specified, the gap between heating and cooling setpoints is the deadband.
     #[serde(default)]
@@ -57,8 +65,12 @@ pub enum ThermostatMode {
 /// Zone thermostat controller.
 ///
 /// Operates on one or more zones (via ZoneGroup or individual zones).
-/// Reads zone temperatures, determines heating/cooling mode, and calculates
-/// the required supply air temperature and flow to meet the load.
+/// Reads zone temperatures and emits the zone heating/cooling setpoints
+/// (occupied + unoccupied) as control actions. It is the *setpoint authority*:
+/// it decides what temperature each zone wants. How that setpoint is met —
+/// supply air temperature, flow, coil/plant response — is the job of the HVAC
+/// engine (`simulate_all_loops`), not the thermostat. This split keeps control
+/// authority and capacity response from being computed twice (see issue #75).
 #[derive(Debug)]
 pub struct ZoneThermostat {
     name: String,
@@ -66,12 +78,6 @@ pub struct ZoneThermostat {
     zone_groups: Vec<ZoneGroup>,
     /// Individual zones with their own setpoints (for zones not in a group)
     individual_zones: Vec<ZoneGroup>,
-    /// Design supply air temp for heating [°C]
-    heating_supply_temp: f64,
-    /// Design supply air temp for cooling [°C]
-    cooling_supply_temp: f64,
-    /// Design air flow rate per zone [kg/s] (for load calculation)
-    design_zone_flow: f64,
 
     /// Current control actions (rebuilt each timestep)
     current_actions: Vec<ControlAction>,
@@ -81,20 +87,11 @@ pub struct ZoneThermostat {
 
 impl ZoneThermostat {
     /// Create a thermostat from zone groups.
-    pub fn from_groups(
-        name: &str,
-        zone_groups: Vec<ZoneGroup>,
-        heating_supply_temp: f64,
-        cooling_supply_temp: f64,
-        design_zone_flow: f64,
-    ) -> Self {
+    pub fn from_groups(name: &str, zone_groups: Vec<ZoneGroup>) -> Self {
         Self {
             name: name.to_string(),
             zone_groups,
             individual_zones: Vec::new(),
-            heating_supply_temp,
-            cooling_supply_temp,
-            design_zone_flow,
             current_actions: Vec::new(),
             zone_modes: std::collections::HashMap::new(),
         }
@@ -106,24 +103,22 @@ impl ZoneThermostat {
         zone: &str,
         heating_setpoint: f64,
         cooling_setpoint: f64,
-        heating_supply_temp: f64,
-        cooling_supply_temp: f64,
-        design_zone_flow: f64,
+        unoccupied_heating_setpoint: f64,
+        unoccupied_cooling_setpoint: f64,
     ) -> Self {
         let group = ZoneGroup {
             name: zone.to_string(),
             zones: vec![zone.to_string()],
             heating_setpoint,
             cooling_setpoint,
+            unoccupied_heating_setpoint: Some(unoccupied_heating_setpoint),
+            unoccupied_cooling_setpoint: Some(unoccupied_cooling_setpoint),
             deadband: None,
         };
         Self {
             name: name.to_string(),
             zone_groups: vec![group],
             individual_zones: Vec::new(),
-            heating_supply_temp,
-            cooling_supply_temp,
-            design_zone_flow,
             current_actions: Vec::new(),
             zone_modes: std::collections::HashMap::new(),
         }
@@ -137,57 +132,6 @@ impl ZoneThermostat {
             ThermostatMode::Cooling
         } else {
             ThermostatMode::Deadband
-        }
-    }
-
-    /// Calculate required supply air temperature to meet zone load.
-    ///
-    /// For heating: supply temp must be above zone temp to add heat.
-    /// For cooling: supply temp must be below zone temp to remove heat.
-    /// Uses the proportional approach: the further from setpoint, the more
-    /// extreme the supply temp (up to the design limits).
-    fn calc_supply_temp(
-        zone_temp: f64,
-        setpoint: f64,
-        mode: ThermostatMode,
-        heating_supply_temp: f64,
-        cooling_supply_temp: f64,
-    ) -> f64 {
-        match mode {
-            ThermostatMode::Heating => {
-                // Proportional: if zone is far below setpoint, use full heating supply temp.
-                // If zone is close to setpoint, reduce supply temp.
-                let error = setpoint - zone_temp;
-                let max_error = 5.0; // °C — full output at 5°C error
-                let frac = (error / max_error).clamp(0.0, 1.0);
-                // Blend between zone temp and design heating supply temp
-                zone_temp + frac * (heating_supply_temp - zone_temp)
-            }
-            ThermostatMode::Cooling => {
-                let error = zone_temp - setpoint;
-                let max_error = 5.0;
-                let frac = (error / max_error).clamp(0.0, 1.0);
-                zone_temp - frac * (zone_temp - cooling_supply_temp)
-            }
-            _ => zone_temp, // Deadband/off — supply at zone temp (no load)
-        }
-    }
-
-    /// Calculate required air mass flow rate to meet zone load.
-    fn calc_zone_flow(
-        zone_temp: f64,
-        setpoint: f64,
-        mode: ThermostatMode,
-        design_flow: f64,
-    ) -> f64 {
-        match mode {
-            ThermostatMode::Heating | ThermostatMode::Cooling => {
-                let error = (zone_temp - setpoint).abs();
-                let max_error = 5.0;
-                let frac = (error / max_error).clamp(0.1, 1.0); // minimum 10% flow
-                design_flow * frac
-            }
-            _ => design_flow * 0.1, // Deadband: minimum ventilation
         }
     }
 
@@ -213,40 +157,30 @@ impl Controller for ZoneThermostat {
         let all_groups = self.zone_groups.iter().chain(self.individual_zones.iter());
 
         for group in all_groups {
+            // Unoccupied setpoints fall back to the occupied values (no setback)
+            // when the group doesn't specify them.
+            let unocc_heat = group
+                .unoccupied_heating_setpoint
+                .unwrap_or(group.heating_setpoint);
+            let unocc_cool = group
+                .unoccupied_cooling_setpoint
+                .unwrap_or(group.cooling_setpoint);
+
             for zone_name in &group.zones {
                 let zone_temp = state.zone_temp(zone_name);
 
+                // Mode is reported for introspection/tests; the HVAC engine
+                // decides the actual supply response from the emitted setpoints.
                 let mode =
                     Self::determine_mode(zone_temp, group.heating_setpoint, group.cooling_setpoint);
-
                 self.zone_modes.insert(zone_name.clone(), mode);
 
-                // Calculate target supply air temp for this zone
-                let setpoint = match mode {
-                    ThermostatMode::Heating => group.heating_setpoint,
-                    ThermostatMode::Cooling => group.cooling_setpoint,
-                    _ => zone_temp,
-                };
-
-                let supply_temp = Self::calc_supply_temp(
-                    zone_temp,
-                    setpoint,
-                    mode,
-                    self.heating_supply_temp,
-                    self.cooling_supply_temp,
-                );
-
-                let mass_flow =
-                    Self::calc_zone_flow(zone_temp, setpoint, mode, self.design_zone_flow);
-
-                self.current_actions.push(ControlAction::SetZoneSupplyTemp {
+                self.current_actions.push(ControlAction::SetZoneSetpoints {
                     zone: zone_name.clone(),
-                    supply_temp,
-                });
-
-                self.current_actions.push(ControlAction::SetZoneAirFlow {
-                    zone: zone_name.clone(),
-                    mass_flow,
+                    heating_setpoint: group.heating_setpoint,
+                    cooling_setpoint: group.cooling_setpoint,
+                    unoccupied_heating_setpoint: unocc_heat,
+                    unoccupied_cooling_setpoint: unocc_cool,
                 });
             }
         }
@@ -289,16 +223,12 @@ mod tests {
             zones: vec!["East".to_string(), "West".to_string(), "North".to_string()],
             heating_setpoint: 21.0,
             cooling_setpoint: 24.0,
+            unoccupied_heating_setpoint: None,
+            unoccupied_cooling_setpoint: None,
             deadband: None,
         };
 
-        let mut thermostat = ZoneThermostat::from_groups(
-            "Office Thermostat",
-            vec![group],
-            35.0, // heating supply temp
-            13.0, // cooling supply temp
-            0.5,  // design zone flow
-        );
+        let mut thermostat = ZoneThermostat::from_groups("Office Thermostat", vec![group]);
 
         // All zones cold
         let mut state = SystemState::new(MoistAirState::from_tdb_rh(0.0, 0.5, 101325.0));
@@ -314,8 +244,8 @@ mod tests {
         assert_eq!(thermostat.zone_mode("West"), ThermostatMode::Heating);
         assert_eq!(thermostat.zone_mode("North"), ThermostatMode::Heating);
 
-        // Should have 6 actions (2 per zone: supply temp + flow)
-        assert_eq!(thermostat.actions().len(), 6);
+        // One SetZoneSetpoints action per zone.
+        assert_eq!(thermostat.actions().len(), 3);
     }
 
     #[test]
@@ -329,11 +259,12 @@ mod tests {
             ],
             heating_setpoint: 21.0,
             cooling_setpoint: 24.0,
+            unoccupied_heating_setpoint: None,
+            unoccupied_cooling_setpoint: None,
             deadband: None,
         };
 
-        let mut thermostat =
-            ZoneThermostat::from_groups("Mixed Thermostat", vec![group], 35.0, 13.0, 0.5);
+        let mut thermostat = ZoneThermostat::from_groups("Mixed Thermostat", vec![group]);
 
         let mut state = SystemState::new(MoistAirState::from_tdb_rh(20.0, 0.5, 101325.0));
         state.zone_temps.insert("ZoneA".to_string(), 19.0); // needs heating
@@ -354,10 +285,9 @@ mod tests {
             "Living Room",
             "Living Room",
             21.0,
-            24.0, // heating/cooling setpoints
-            35.0,
-            13.0, // supply temps
-            0.3,
+            24.0, // occupied heating/cooling setpoints
+            15.6,
+            26.7, // unoccupied setback/setup
         );
 
         let mut state = SystemState::new(MoistAirState::from_tdb_rh(0.0, 0.5, 101325.0));
@@ -367,21 +297,24 @@ mod tests {
         thermostat.update(&state, &ctx);
 
         assert_eq!(thermostat.zone_mode("Living Room"), ThermostatMode::Heating);
-        assert_eq!(thermostat.actions().len(), 2); // supply temp + flow
+        assert_eq!(thermostat.actions().len(), 1); // one setpoint bundle
 
-        // Check that supply temp action has a value above zone temp
+        // The emitted action carries the occupied + unoccupied setpoints.
         match &thermostat.actions()[0] {
-            ControlAction::SetZoneSupplyTemp { supply_temp, .. } => {
-                assert!(
-                    *supply_temp > 18.0,
-                    "Supply temp should be above zone temp for heating"
-                );
-                assert!(
-                    *supply_temp <= 35.0,
-                    "Supply temp should not exceed design heating supply temp"
-                );
+            ControlAction::SetZoneSetpoints {
+                zone,
+                heating_setpoint,
+                cooling_setpoint,
+                unoccupied_heating_setpoint,
+                unoccupied_cooling_setpoint,
+            } => {
+                assert_eq!(zone, "Living Room");
+                assert!((heating_setpoint - 21.0).abs() < 1e-9);
+                assert!((cooling_setpoint - 24.0).abs() < 1e-9);
+                assert!((unoccupied_heating_setpoint - 15.6).abs() < 1e-9);
+                assert!((unoccupied_cooling_setpoint - 26.7).abs() < 1e-9);
             }
-            _ => panic!("Expected SetZoneSupplyTemp action"),
+            _ => panic!("Expected SetZoneSetpoints action"),
         }
     }
 
@@ -392,6 +325,8 @@ mod tests {
             zones: vec!["Office1".to_string(), "Office2".to_string()],
             heating_setpoint: 21.0,
             cooling_setpoint: 24.0,
+            unoccupied_heating_setpoint: None,
+            unoccupied_cooling_setpoint: None,
             deadband: None,
         };
         let server = ZoneGroup {
@@ -399,16 +334,13 @@ mod tests {
             zones: vec!["Server".to_string()],
             heating_setpoint: 18.0, // server room can be cooler
             cooling_setpoint: 22.0, // but needs more cooling
+            unoccupied_heating_setpoint: None,
+            unoccupied_cooling_setpoint: None,
             deadband: None,
         };
 
-        let mut thermostat = ZoneThermostat::from_groups(
-            "Building Thermostat",
-            vec![offices, server],
-            35.0,
-            13.0,
-            0.5,
-        );
+        let mut thermostat =
+            ZoneThermostat::from_groups("Building Thermostat", vec![offices, server]);
 
         let mut state = SystemState::new(MoistAirState::from_tdb_rh(20.0, 0.5, 101325.0));
         state.zone_temps.insert("Office1".to_string(), 19.0); // heating (below 21)

--- a/crates/openbse-io/src/input.rs
+++ b/crates/openbse-io/src/input.rs
@@ -3562,51 +3562,23 @@ pub fn build_controllers(model: &ModelInput) -> Vec<Box<dyn Controller>> {
     // Resolve thermostats, expanding zone group references to individual zones.
     let resolved_thermostats = resolve_thermostats(model);
 
-    // Default supply temps and design flow — these will come from air loop
-    // controls once Phase 2 is wired up. For now, use standard defaults.
-    let default_heating_supply = 35.0; // °C
-    let default_cooling_supply = 13.0; // °C
-    let default_zone_flow = 0.5; // kg/s
-
+    // Each thermostat becomes a setpoint authority for its zones. It emits the
+    // occupied + unoccupied heating/cooling setpoints; the HVAC engine computes
+    // the supply response. Supply temps and design flows are NOT a thermostat
+    // concern — they come from air-loop controls in the live engine.
     for tstat in &resolved_thermostats {
         let group = ZoneGroup {
             name: tstat.name.clone(),
             zones: tstat.zones.clone(),
             heating_setpoint: tstat.heating_setpoint,
             cooling_setpoint: tstat.cooling_setpoint,
+            unoccupied_heating_setpoint: Some(tstat.unoccupied_heating_setpoint),
+            unoccupied_cooling_setpoint: Some(tstat.unoccupied_cooling_setpoint),
             deadband: None,
         };
 
-        // Look up air loop controls for supply temps + design flow.
-        // Find the first air loop that serves any of this thermostat's zones.
-        let (heat_supply, cool_supply, zone_flow) = model
-            .air_loops
-            .iter()
-            .find(|al| {
-                al.zone_terminals
-                    .iter()
-                    .any(|zc| tstat.zones.contains(&zc.zone))
-            })
-            .map(|al| {
-                (
-                    al.controls.heating_supply_temp,
-                    al.controls.cooling_supply_temp,
-                    al.controls.design_zone_flow.to_f64(),
-                )
-            })
-            .unwrap_or((
-                default_heating_supply,
-                default_cooling_supply,
-                default_zone_flow,
-            ));
-
-        let thermostat = ZoneThermostat::from_groups(
-            &format!("{} Thermostat", tstat.name),
-            vec![group],
-            heat_supply,
-            cool_supply,
-            zone_flow,
-        );
+        let thermostat =
+            ZoneThermostat::from_groups(&format!("{} Thermostat", tstat.name), vec![group]);
         controllers.push(Box::new(thermostat));
     }
 


### PR DESCRIPTION
Closes part of #75 (the framework wiring; see PR-B follow-up below).

## Problem

`build_controllers()` output was dropped on the simulation path — the `Controller` trait's `update()`/`actions()` were never called, so the `openbse-controls` crate was dead and the YAML `controls:` block was silently inert (issue #75).

## What this PR does (behavior-preserving)

Wires the controller layer in as the **zone setpoint authority**, feeding the existing validated HVAC engine rather than replacing it:

- New `ControlAction::SetZoneSetpoints` carries heating/cooling **and** unoccupied setpoints — the controller owns its full deadband.
- `ZoneThermostat` emits that bundle and no longer emits the proportional supply-temp/flow model, which did not match the engine's predictor-corrector / capacity-based control (called out in #75). Control authority (what the zone wants) and capacity response (how `simulate_all_loops` delivers it) are now cleanly separated.
- `main.rs` sources the per-zone setpoint maps from the controllers' `SetZoneSetpoints` actions instead of a parallel `resolve_thermostats` pass — a single source of truth. `update()`/`actions()` are now genuinely on the live path.
- Explicit `controls:` setpoint managers / plant-loop setpoints now emit a validation **warning** on the coupled envelope+HVAC path instead of silently no-op'ing.

## Note on approach

This does **not** route the live loop through `SimulationRunner::run_with_controls`. That runner — along with `run_with_controls` and `simulate_timestep` — is dead code workspace-wide (referenced nowhere outside its own module); the validated engine is `simulate_all_loops` in `main.rs`. Routing through the runner would discard the ASHRAE-140-validated physics. The controller layer instead feeds the existing engine, keeping a single control convention.

Thermostat setpoints are static, so controllers are evaluated once. Per-timestep evaluation at the predictor step (needed for schedule-varying / sensed-state setpoints) lands with the dynamic-controls follow-up, where it changes behavior and can be validated on its own.

## Verification

- **ASHRAE 140: 37/37 case `results.csv` byte-identical** before/after.
- **Real-HVAC examples + prototypes** (incl. `simple_heating`, which uses zone-group thermostats + a `controls:` block): `results.csv` and `zone_sizing` byte-identical; `system_sizing` content-identical (only pre-existing HashMap row-ordering, reproduced by running the same binary twice).
- `cargo fmt --check`, `cargo clippy --workspace` (zero new warnings), `cargo test --workspace` all clean.

## Follow-up (PR-B)

A follow-up will make the `controls:` block actually drive components on the coupled path (setpoint managers, plant-loop setpoints via `ControlSignals`) and move controller evaluation to the predictor step for dynamic/scheduled setpoints — now testable because the path is live and trusted.

https://claude.ai/code/session_01Cay4xp5usa6AgmrNErabRq